### PR TITLE
ConsoleAppender doesn't have 'append' property, causes ERROR msg on startup

### DIFF
--- a/src/main/resources/logback.groovy
+++ b/src/main/resources/logback.groovy
@@ -41,7 +41,6 @@ appender(rollingFile, RollingFileAppender) {
 }
 
 appender(console, ConsoleAppender) {
-    append = true
     encoder(PatternLayoutEncoder) {
         pattern = logPattern
     }


### PR DESCRIPTION
`append` makes no sense for `ConsoleAppender`, causes non-critical:

```
|-ERROR in ch.qos.logback.classic.gaffer.AppenderDelegate@f58853c - Appender [CONSOLE] of type [ch.qos.logback.core.ConsoleAppender] has no appplicable [append] property
```

BTW do you really want this?

```
statusListener(OnConsoleStatusListener)
```

Produces a lot of DEBUG noise during startup.
