### PR TITLE
Testing libs update and exclude old servlet-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     compile 'com.google.guava:guava:18.0'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'org.apache.tomcat.embed:tomcat-embed-el:8.0.14'
-    compile 'com.jayway.jsonpath:json-path-assert:1.1.0'
+    compile 'com.jayway.jsonpath:json-path-assert:1.2.0'
     compile 'org.yaml:snakeyaml:1.14'
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'org.hibernate:hibernate-validator:5.1.3.Final'
@@ -108,7 +108,9 @@ dependencies {
     testCompile "org.spockframework:spock-core:$spockVersion"
     testRuntime "org.spockframework:spock-spring:$spockVersion"
     testCompile "org.springframework:spring-test:$springVersion"
-    testCompile 'com.github.tomakehurst:wiremock:1.51'
+    testCompile('com.github.tomakehurst:wiremock:1.52'){
+        exclude group: 'org.mortbay.jetty', module: 'servlet-api'
+    }
     testCompile "com.ofg:micro-infra-spring-test:$microInfraSpringVersion"
 }
 


### PR DESCRIPTION
- matchingJsonPath in wiremock is not supported!
