### PR TITLE
Move micro-infra-spring version to gradle.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ ext {
     currentVersion = "${versionPrefix}-${buildNrLoc}"
 
     jacksonMapper = '1.9.13'
-    microInfraSpringVersion = '0.8.4'
+    //microInfraSpring version moved to gradle.properties
 }
 
 uploadArchives {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+microInfraSpringVersion=0.8.4


### PR DESCRIPTION
To make it easier to bump micro-infra-spring version on CI server.