### PR TITLE
[#58] GUI tests can be run on external application instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ test {
 }
 
 task guiTest(type: Test) {
+    jvmArgs project.gradle.startParameter.systemPropertiesArgs.entrySet().collect{"-D${it.key}=${it.value}"}
+    testLogging {
+        exceptionFormat = 'full'
+    }
     include '**/*UISpec.*'
 
     reports.html {

--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -1,7 +1,11 @@
 import org.openqa.selenium.Dimension
 import org.openqa.selenium.firefox.FirefoxDriver
 
-baseUrl="http://localhost:8095"
+//baseUrl in this file has precedence over -Dgeb.build.baseUrl, so set it only if system property is not defined
+if (!System.getProperty("geb.build.baseUrl")) {
+    baseUrl="http://localhost:8095"
+}
+
 driver = {
     def firefoxDriver = new FirefoxDriver()
     firefoxDriver.manage().window().setSize(new Dimension(1600,1200))


### PR DESCRIPTION
With -Dgeb.build.baseUrl="http://staging-env:9009"