### PR TITLE
Add support for generic application url property for smoke tests

### DIFF
--- a/src/test/resources/GebConfig.groovy
+++ b/src/test/resources/GebConfig.groovy
@@ -1,9 +1,14 @@
 import org.openqa.selenium.Dimension
 import org.openqa.selenium.firefox.FirefoxDriver
 
-//baseUrl in this file has precedence over -Dgeb.build.baseUrl, so set it only if system property is not defined
-if (!System.getProperty("geb.build.baseUrl")) {
-    baseUrl="http://localhost:8095"
+String smokeTestAppUrlProp = System.getProperty("smokeTestAppUrl")
+if (smokeTestAppUrlProp) {
+    baseUrl = smokeTestAppUrlProp
+} else {
+    //baseUrl in this file has precedence over -Dgeb.build.baseUrl, so set it only if system property is not defined
+    if (!System.getProperty("geb.build.baseUrl")) {
+        baseUrl = "http://localhost:8095"
+    }
 }
 
 driver = {


### PR DESCRIPTION
To make it easier to use other frameworks for smoke testing
when running from CI server.