### PR TITLE
accurest update and fixed typo in package name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ jacksonMapper=1.9.13
 gebVersion=0.10.0
 seleniumVersion=2.45.0
 restAssuredVersion=2.4.1
-accurestVersion=0.4.5
+accurestVersion=0.6.8

--- a/repository/mappings/com/ofg/twitter-places-analyzer/pairId/colleratePlacesFromTweet.groovy
+++ b/repository/mappings/com/ofg/twitter-places-analyzer/pairId/colleratePlacesFromTweet.groovy
@@ -1,4 +1,4 @@
-io.coderate.accurest.dsl.GroovyDsl.make {
+io.codearte.accurest.dsl.GroovyDsl.make {
     request {
         method 'PUT'
         url '/api/12'


### PR DESCRIPTION
Fix for building error with new accurest:

```
:generateWiremockClientStubs FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':generateWiremockClientStubs'.
> Unable to convertion of colleratePlacesFromTweet.groovy
```

Stacktrace:

```
Caused by: groovy.lang.MissingPropertyException: No such property: io for class: Script1
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:50)
	at org.codehaus.groovy.runtime.callsite.PogoGetPropertySite.getProperty(PogoGetPropertySite.java:49)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:231)
	at Script1.run(Script1.groovy:1)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:570)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:608)
	at groovy.lang.GroovyShell.evaluate(GroovyShell.java:579)
	at io.codearte.accurest.wiremock.DslToWiremockConverter.createGroovyDSLfromStringContent(DslToWiremockConverter.groovy:20)
	at io.codearte.accurest.wiremock.DslToWiremockClientConverter.convertContent(DslToWiremockClientConverter.groovy:11)
	at io.codearte.accurest.wiremock.RecursiveFilesConverter$_processFiles_closure1.doCall(RecursiveFilesConverter.groovy:31)
```