### PR TITLE
LoadBalancer configuration fix for microInfraSpringVersion 2.0.6

### DIFF
--- a/src/main/groovy/com/ofg/twitter/config/LoadBalancedRestTemplateConfiguration.groovy
+++ b/src/main/groovy/com/ofg/twitter/config/LoadBalancedRestTemplateConfiguration.groovy
@@ -1,4 +1,4 @@
-package com.ofg.twitter.places
+package com.ofg.twitter.config
 
 import org.springframework.cloud.client.loadbalancer.LoadBalanced
 import org.springframework.context.annotation.Bean

--- a/src/test/groovy/com/ofg/twitter/places/SpringCloudAcceptanceSpec.groovy
+++ b/src/test/groovy/com/ofg/twitter/places/SpringCloudAcceptanceSpec.groovy
@@ -1,5 +1,6 @@
 package com.ofg.twitter.places
 
+import com.ofg.twitter.config.LoadBalancedRestTemplateConfiguration
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 


### PR DESCRIPTION
In microInfraSpringVersion 2.0.6 app was failing because of missing restTemplate bean. There was this bean in defined in LoadBalancedRestTemplateConfiguration class int tests folder (it was reason why guiTest runs correct), so I moved this configuration into src. App is runnable with this solution.