### PR TITLE
Making Wiremock version inherited from micro-infra-spring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     runtime 'com.h2database:h2'
 
     testCompile 'com.jayway.awaitility:awaitility:1.6.5'
-    testCompile 'com.github.tomakehurst:wiremock:2.0.5-beta'
+    testCompile 'com.github.tomakehurst:wiremock'
     testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile "com.ofg:micro-infra-spring-test:$microInfraSpringVersion"
 


### PR DESCRIPTION
Hardocoded verion of Wiremock cause failure of boot microservice acceptance test executed during micro-infra-spring build.

> Caused by: java.lang.NoClassDefFoundError: Unable to load class com.ofg.infrastructure.base.MvcWiremockIntegrationSpec due to missing dependency com/github/tomakehurst/wiremock/client/RemoteMappingBuilder

See https://travis-ci.org/4finance/micro-infra-spring/builds/130784099