### PR TITLE
Switch Travis to Docker-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,15 @@ env:
 after_success:
 - ./gradlew test jacocoTestReport coveralls -Pcoverage
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.gradle/caches/*/scripts/
+  - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
+  - rm -fr $HOME/.gradle/caches/*/fileHashes/
+  - rm -fr $HOME/.gradle/caches/transforms-1/transforms-1.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: groovy
-sudo: true
+sudo: false
 jdk:
 - oraclejdk8
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -37,6 +37,8 @@ test {
 
 task guiTest(type: Test) {
     jvmArgs project.gradle.startParameter.systemPropertiesArgs.entrySet().collect{"-D${it.key}=${it.value}"}
+    jvmArgs '-Xmx1g'
+
     testLogging {
         exceptionFormat = 'full'
     }


### PR DESCRIPTION
Required to make micro-infra-spring run on that infrastructure with [Build Stages](https://docs.travis-ci.com/user/build-stages) (such as [that](https://travis-ci.org/4finance/micro-infra-spring/builds/248868755)).

To do that more memory is allowed for tests (to do not finish up with Gradle killed - error 137). 

By the way caching has been enabled.