### PR TITLE
Bumping micro-infra-spring to 2.0.47 (Spring Cloud Edgware.SR1)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ microInfraStubrunnerUseMicroserviceDefinitions=true
 # change the root package: all paths to support new package structure (com.ofg -> com.some.other.company)
 
 # Versions
-microInfraSpringVersion=2.0.46
+microInfraSpringVersion=2.0.47
 gebVersion=2.0
 seleniumVersion=3.1.0
 restAssuredVersion=3.0.6


### PR DESCRIPTION
See [micro-infra release notes](https://github.com/4finance/micro-infra-spring/releases/tag/release%2F2.0.47).